### PR TITLE
js dict storage for config settings

### DIFF
--- a/src/pebble-js-app.js
+++ b/src/pebble-js-app.js
@@ -34,6 +34,9 @@ Pebble.addEventListener('showConfiguration', function(e) {
             localStorage.setItem('vibrate_disconnect', true);
     */
     /* DEBUG */
+
+    var URL = 'http://clach04.github.io/pebble/watchface_framework/slate/index.html';
+
     var default_dict = {
         version_settings: 0,  // Bump this when ever config storage changes
         // http://developer.getpebble.com/tools/color-picker/
@@ -84,9 +87,9 @@ Pebble.addEventListener('showConfiguration', function(e) {
         temp_str = config_key + '=' + encodeURIComponent(configuration[config_key]);
         param_array.push(temp_str);
     }
-    var URL = 'http://clach04.github.io/pebble/watchface_framework/slate/index.html' + '?' + param_array.join('&');
-    console.log('Configuration window opened. ' + URL);
-    Pebble.openURL(URL);
+    var URL_with_params = URL + '?' + param_array.join('&');
+    console.log('Configuration window opened. ' + URL_with_params);
+    Pebble.openURL(URL_with_params);
 });
 
 Pebble.addEventListener('webviewclosed',

--- a/src/pebble-js-app.js
+++ b/src/pebble-js-app.js
@@ -207,15 +207,10 @@ Pebble.addEventListener('webviewclosed',
             localStorage.setItem('stored_dict', JSON.stringify(configuration));
 
             // Send to Pebble
-            var vibrate_disconnect = 0;
-            if (force_bool(configuration.vibrate_disconnect))
-            {
-                vibrate_disconnect = 1;
-            }
             var dictionary = {
               "KEY_TIME_COLOR": parseInt(configuration.time_color, 16),  // TODO color not validated
               "KEY_BACKGROUND_COLOR": parseInt(configuration.background_color, 16),  // TODO color not validated
-              "KEY_VIBRATE_ON_DISCONNECT": vibrate_disconnect
+              "KEY_VIBRATE_ON_DISCONNECT": force_bool(configuration.vibrate_disconnect) ? 1 : 0  // Force to int
             };
 
             console.log('dictionary to send to Pebble' + JSON.stringify(dictionary));

--- a/src/pebble-js-app.js
+++ b/src/pebble-js-app.js
@@ -202,7 +202,7 @@ Pebble.addEventListener('webviewclosed',
             var configuration = merge_options(default_dict, configuration_from_page);
 
             /* Validate config */
-            configuration.vibrate_disconnect = force_bool(configuration.vibrate_disconnect);
+            configuration.vibrate_disconnect = force_bool(configuration.vibrate_disconnect) ? 1 : 0;  // Force to int
 
             /* even though we don't really trust `configuration`, store it in local phone storage */
             // TODO store (validated) dictionary (below) instead - which stores color settings differently
@@ -213,7 +213,7 @@ Pebble.addEventListener('webviewclosed',
             var dictionary = {
               "KEY_TIME_COLOR": parseInt(configuration.time_color, 16),  // TODO color not validated
               "KEY_BACKGROUND_COLOR": parseInt(configuration.background_color, 16),  // TODO color not validated
-              "KEY_VIBRATE_ON_DISCONNECT": configuration.vibrate_disconnect ? 1 : 0  // Force to int
+              "KEY_VIBRATE_ON_DISCONNECT": configuration.vibrate_disconnect
             };
 
             console.log('dictionary to send to Pebble' + JSON.stringify(dictionary));

--- a/src/pebble-js-app.js
+++ b/src/pebble-js-app.js
@@ -9,6 +9,34 @@ var default_dict = {
 };
 
 
+function force_bool(in_value)
+{
+    var result=false;
+
+    switch (in_value)
+    {
+        case true:
+        case 'true':
+        case 'True':
+        case 'TRUE':
+        case 1:
+        case '1':
+        case 'on':
+        case 'On':
+        case 'ON':
+        case 'yes':
+        case 'Yes':
+        case 'YES':
+        case 'Y':
+            result = true;
+            break;
+        default:
+            result = false;
+            break;
+    }
+    return result;
+}
+
 function getStorageValue(item, default_value){
     var retVal = localStorage.getItem(item);
     //console.log('value' + item + ': ' + String(retVal));
@@ -182,19 +210,9 @@ Pebble.addEventListener('webviewclosed',
             var vibrate_disconnect = 0;
             if ('vibrate_disconnect' in configuration)
             {
-                switch (configuration.vibrate_disconnect) {
-                    case true:
-                    case 'true':
-                    case 'True':
-                    case 'TRUE':
-                    case 1:
-                    case '1':
-                    case 'on':
-                        vibrate_disconnect = 1;
-                        break;
-                    default:
-                        vibrate_disconnect = 0;
-                        break;
+                if (force_bool(configuration.vibrate_disconnect))
+                {
+                    vibrate_disconnect = 1;
                 }
             }
             var dictionary = {

--- a/src/pebble-js-app.js
+++ b/src/pebble-js-app.js
@@ -55,31 +55,22 @@ Pebble.addEventListener('showConfiguration', function(e) {
     console.log('stored_dict: ' + JSON.stringify(stored_dict));
     console.log('default_dict: ' + JSON.stringify(default_dict));
 
-    // TODO replace with a loop, remove duplicate code
-  var background_color = getStorageValue('background_color', null);
-    if (background_color !== null)
+    /* Handle old config - not stored in dict */
+    console.log('Checking old (non-dict) config items');
+    var old_config_names = ['background_color', 'time_color', 'vibrate_disconnect'];
+    for (var i in old_config_names)
     {
-        default_dict.background_color = background_color;
-        console.log('about to remove old localStorage item background_color');
-        localStorage.removeItem('background_color');
+        var config_name=old_config_names[i];
+        var tmp_setting;
+        console.log('i=' + i + '=' + config_name);
+        tmp_setting = getStorageValue(config_name, null);
+        if (tmp_setting !== null)
+        {
+            default_dict[config_name] = tmp_setting;
+            console.log('about to remove old localStorage item ' + config_name);
+            localStorage.removeItem(config_name);
+        }
     }
-
-  var time_color = getStorageValue('time_color', null);
-    if (time_color !== null)
-    {
-        default_dict.time_color = time_color;
-        console.log('about to remove old localStorage item time_color');
-        localStorage.removeItem('time_color');
-    }
-
-  var vibrate_disconnect = getStorageValue('vibrate_disconnect', null);
-    if (vibrate_disconnect !== null)
-    {
-        default_dict.vibrate_disconnect = vibrate_disconnect;
-        console.log('about to remove old localStorage item vibrate_disconnect');
-        localStorage.removeItem('vibrate_disconnect');
-    }
-
 
     var configuration = merge_options(default_dict, stored_dict);
     console.log('configuration: ' + JSON.stringify(configuration));

--- a/src/pebble-js-app.js
+++ b/src/pebble-js-app.js
@@ -56,6 +56,66 @@ Pebble.addEventListener('showConfiguration', function(e) {
         stored_dict = JSON.parse(stored_dict_str);
     }
     console.log('stored_dict: ' + JSON.stringify(stored_dict));
+    if (Pebble.getActiveWatchInfo)
+    {
+        /*
+        ** SDK v3 or higher.
+        ** E.g. Basalt, Chalk, or Aplite with 3.8+
+        */
+        var info = Pebble.getActiveWatchInfo();
+        console.log('Pebble info: ' + JSON.stringify(info));
+        default_dict.pebble_platform = info.platform;
+        default_dict.pebble_model = info.model;
+        default_dict.pebble_language = info.language;
+        /*
+        ** Useful info:
+            platform: aplite|basalt|chalk
+            model: qemu_platform_aplite|qemu_platform_basalt|qemu_platform_chalk|pebble_time_black
+
+        Seen in emulator:
+        {
+            "platform": "aplite",
+            "model": "qemu_platform_aplite",
+            "firmware": {
+                "major": 3,
+                "suffix": "",
+                "minor": 3,
+                "patch": 1
+            },
+            "language": "en_US"
+        }
+        {
+            "platform": "basalt",
+            "model": "qemu_platform_basalt",
+            "firmware": {
+                "major": 3,
+                "suffix": "",
+                "minor": 3,
+                "patch": 1
+            },
+            "language": "en_US"
+        }
+        {
+            "platform": "chalk",
+            "model": "qemu_platform_chalk",
+            "firmware": {
+                "major": 3,
+                "suffix": "",
+                "minor": 3,
+                "patch": 1
+            },
+            "language": "en_US"
+        }
+        */
+    }
+    else
+    {
+        /*
+        ** Info NOT available with SDK pre v3. Probably old Aplite.
+        ** NOTE emulator with 3.8 SDK for aplite does have this info.
+        */
+    }
+
     console.log('default_dict: ' + JSON.stringify(default_dict));
 
     /* Handle old config - not stored in dict */

--- a/src/pebble-js-app.js
+++ b/src/pebble-js-app.js
@@ -204,9 +204,13 @@ Pebble.addEventListener('webviewclosed',
             /* Validate config */
             configuration.vibrate_disconnect = force_bool(configuration.vibrate_disconnect) ? 1 : 0;  // Force to int
 
-            /* even though we don't really trust `configuration`, store it in local phone storage */
-            // TODO store (validated) dictionary (below) instead - which stores color settings differently
-            console.log('store config on phone');
+            /*
+            ** even though we don't really trust `configuration`, store it in local phone storage
+            ** TODO store (validated) dictionary (below) on phone instead
+            **    - key names different
+            **    - color settings string (hex) versus int number
+            */
+            console.log('store config on phone: ' + JSON.stringify(configuration));
             localStorage.setItem('stored_dict', JSON.stringify(configuration));
 
             // Send to Pebble

--- a/src/pebble-js-app.js
+++ b/src/pebble-js-app.js
@@ -1,3 +1,14 @@
+var URL = 'http://clach04.github.io/pebble/watchface_framework/slate/index.html';
+
+var default_dict = {
+    version_settings: 0,  // Bump this when ever config storage changes
+    // http://developer.getpebble.com/tools/color-picker/
+    background_color: '000000',  // GColorBlack
+    time_color: 'FFFFFF',  // GColorWhite
+    vibrate_disconnect: 0
+};
+
+
 function getStorageValue(item, default_value){
     var retVal = localStorage.getItem(item);
     //console.log('value' + item + ': ' + String(retVal));
@@ -35,15 +46,6 @@ Pebble.addEventListener('showConfiguration', function(e) {
     */
     /* DEBUG */
 
-    var URL = 'http://clach04.github.io/pebble/watchface_framework/slate/index.html';
-
-    var default_dict = {
-        version_settings: 0,  // Bump this when ever config storage changes
-        // http://developer.getpebble.com/tools/color-picker/
-        background_color: '000000',  // GColorBlack
-        time_color: 'FFFFFF',  // GColorWhite
-        vibrate_disconnect: 0
-    };
     var stored_dict_str = getStorageValue('stored_dict', null);
     console.log('stored_dict_str: ' + stored_dict_str);
     var stored_dict;

--- a/src/pebble-js-app.js
+++ b/src/pebble-js-app.js
@@ -7,26 +7,104 @@ function getStorageValue(item, default_value){
     return retVal;
 }
 
-Pebble.addEventListener('showConfiguration', function(e) {
-  // http://developer.getpebble.com/tools/color-picker/
-  var background_color = getStorageValue('background_color', '000000'); // GColorBlack
-  var time_color = getStorageValue('time_color', 'FFFFFF'); // GColorWhite
-  var vibrate_disconnect_str = 'off';
-  var vibrate_disconnect = getStorageValue('vibrate_disconnect', 0);
-  if (vibrate_disconnect == 1)
-  {
-      vibrate_disconnect_str = 'on';
-  }
-  else
-  {
-      vibrate_disconnect_str = 'off';
-  }
+/**
+ * Overwrites obj1's values with obj2's and adds obj2's if non existent in obj1
+ * @param obj1
+ * @param obj2
+ * @returns obj3 a new object based on obj1 and obj2
+ * Similar to ES6 Object.assign() but without side effects and works with older js implementations
+ * See
+ *    * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
+ *    * http://stackoverflow.com/questions/171251/how-can-i-merge-properties-of-two-javascript-objects-dynamically
+ */
+function merge_options(obj1, obj2){
+    var obj3 = {};
+    var attrname;
 
+    for (attrname in obj1) { obj3[attrname] = obj1[attrname]; }
+    for (attrname in obj2) { obj3[attrname] = obj2[attrname]; }
+    return obj3;
+}
+
+Pebble.addEventListener('showConfiguration', function(e) {
+    /* DEBUG test old settings are handled and cleaned up */
+    /*
+            localStorage.setItem('background_color', '0000FF');
+            localStorage.setItem('time_color', 'FFFF00');
+            localStorage.setItem('vibrate_disconnect', true);
+    */
+    /* DEBUG */
+    var default_dict = {
+        version_settings: 0,  // Bump this when ever config storage changes
+        // http://developer.getpebble.com/tools/color-picker/
+        background_color: '000000',  // GColorBlack
+        time_color: 'FFFFFF',  // GColorWhite
+        vibrate_disconnect: 0
+    };
+    var stored_dict_str = getStorageValue('stored_dict', null);
+    console.log('stored_dict_str: ' + stored_dict_str);
+    var stored_dict;
+    if (stored_dict_str === null)
+    {
+        stored_dict = {};
+    }
+    else
+    {
+        stored_dict = JSON.parse(stored_dict_str);
+    }
+    console.log('stored_dict: ' + JSON.stringify(stored_dict));
+    console.log('default_dict: ' + JSON.stringify(default_dict));
+
+    // TODO replace with a loop, remove duplicate code
+  var background_color = getStorageValue('background_color', null);
+    if (background_color === null)
+    {
+        // FIXME loose this....
+        background_color = default_dict.background_color;
+    }
+    else
+    {
+        default_dict.background_color = background_color;
+        console.log('about to remove old localStorage item background_color');
+        localStorage.removeItem('background_color');
+    }
+
+  var time_color = getStorageValue('time_color', null);
+    if (time_color === null)
+    {
+        // FIXME loose this....
+        time_color = default_dict.time_color;
+    }
+    else
+    {
+        default_dict.time_color = time_color;
+        console.log('about to remove old localStorage item time_color');
+        localStorage.removeItem('time_color');
+    }
+
+  var vibrate_disconnect = getStorageValue('vibrate_disconnect', null);
+    if (vibrate_disconnect === null)
+    {
+        // FIXME loose this....
+        vibrate_disconnect = default_dict.vibrate_disconnect;
+    }
+    else
+    {
+        default_dict.vibrate_disconnect = vibrate_disconnect;
+        console.log('about to remove old localStorage item vibrate_disconnect');
+        localStorage.removeItem('vibrate_disconnect');
+    }
+
+
+    var configuration = merge_options(default_dict, stored_dict);
+    console.log('configuration: ' + JSON.stringify(configuration));
+
+    // TODO refactor below to iterate through dict
   var URL = 'http://clach04.github.io/pebble/watchface_framework/slate/index.html' +
       '?' +
-      'background_color=' + encodeURIComponent(background_color) + '&' +
-      'time_color=' + encodeURIComponent(time_color) + '&' +
-      'vibrate_disconnect=' + encodeURIComponent(vibrate_disconnect);
+      'background_color=' + encodeURIComponent(configuration.background_color) + '&' +
+      'time_color=' + encodeURIComponent(configuration.time_color) + '&' +
+      'vibrate_disconnect=' + encodeURIComponent(configuration.vibrate_disconnect);
   console.log('Configuration window opened. ' + URL);
   Pebble.openURL(URL);
 });
@@ -40,6 +118,12 @@ Pebble.addEventListener('webviewclosed',
             var vibrate_disconnect = 0;
 
             console.log('dictionary to validate ' + JSON.stringify(configuration));
+            /*
+            ** configuration can from an external web site, this is not trustworthy
+            ** and so needs validation. This avoids needing to add lots of
+            ** protection to the C code on the Pebble.
+            */
+            // TODO as configuration is untrusted and may be missing values, merge in from default_dict
 
             if ('vibrate_disconnect' in configuration)
             {
@@ -63,13 +147,12 @@ Pebble.addEventListener('webviewclosed',
               "KEY_BACKGROUND_COLOR": parseInt(configuration.background_color, 16), // FIXME if mising default value..
               "KEY_VIBRATE_ON_DISCONNECT": vibrate_disconnect
             };
-            console.log('background_color ' + configuration.background_color);
-            localStorage.setItem('background_color', configuration.background_color);
-            console.log('time_color ' + configuration.time_color);
-            localStorage.setItem('time_color', configuration.time_color);
-            console.log('vibrate_disconnect ' + configuration.vibrate_disconnect);
-            localStorage.setItem('vibrate_disconnect', configuration.vibrate_disconnect);
-            console.log('dictionary to send ' + JSON.stringify(dictionary));
+            /* even though we don't realy trust `configuration`, store it in local phone storage */
+            // TODO store dictionary instead - which stores number differently
+            console.log('store config on phone');
+            localStorage.setItem('stored_dict', JSON.stringify(configuration));
+
+            console.log('dictionary to send to Pebble' + JSON.stringify(dictionary));
             // Send to Pebble
             Pebble.sendAppMessage(dictionary,
                 function(e) {

--- a/src/pebble-js-app.js
+++ b/src/pebble-js-app.js
@@ -99,14 +99,18 @@ Pebble.addEventListener('showConfiguration', function(e) {
     var configuration = merge_options(default_dict, stored_dict);
     console.log('configuration: ' + JSON.stringify(configuration));
 
-    // TODO refactor below to iterate through dict
-  var URL = 'http://clach04.github.io/pebble/watchface_framework/slate/index.html' +
-      '?' +
-      'background_color=' + encodeURIComponent(configuration.background_color) + '&' +
-      'time_color=' + encodeURIComponent(configuration.time_color) + '&' +
-      'vibrate_disconnect=' + encodeURIComponent(configuration.vibrate_disconnect);
-  console.log('Configuration window opened. ' + URL);
-  Pebble.openURL(URL);
+    var param_array = [];
+    var temp_str;
+    var config_key;
+    for (config_key in configuration)
+    {
+        console.log('config_key: ' + config_key + '=' + configuration[config_key]);
+        temp_str = config_key + '=' + encodeURIComponent(configuration[config_key]);
+        param_array.push(temp_str);
+    }
+    var URL = 'http://clach04.github.io/pebble/watchface_framework/slate/index.html' + '?' + param_array.join('&');
+    console.log('Configuration window opened. ' + URL);
+    Pebble.openURL(URL);
 });
 
 Pebble.addEventListener('webviewclosed',

--- a/src/pebble-js-app.js
+++ b/src/pebble-js-app.js
@@ -213,8 +213,8 @@ Pebble.addEventListener('webviewclosed',
                 vibrate_disconnect = 1;
             }
             var dictionary = {
-              "KEY_TIME_COLOR": parseInt(configuration.time_color, 16),
-              "KEY_BACKGROUND_COLOR": parseInt(configuration.background_color, 16),
+              "KEY_TIME_COLOR": parseInt(configuration.time_color, 16),  // TODO color not validated
+              "KEY_BACKGROUND_COLOR": parseInt(configuration.background_color, 16),  // TODO color not validated
               "KEY_VIBRATE_ON_DISCONNECT": vibrate_disconnect
             };
 

--- a/src/pebble-js-app.js
+++ b/src/pebble-js-app.js
@@ -208,12 +208,9 @@ Pebble.addEventListener('webviewclosed',
 
             // Send to Pebble
             var vibrate_disconnect = 0;
-            if ('vibrate_disconnect' in configuration)
+            if (force_bool(configuration.vibrate_disconnect))
             {
-                if (force_bool(configuration.vibrate_disconnect))
-                {
-                    vibrate_disconnect = 1;
-                }
+                vibrate_disconnect = 1;
             }
             var dictionary = {
               "KEY_TIME_COLOR": parseInt(configuration.time_color, 16),

--- a/src/pebble-js-app.js
+++ b/src/pebble-js-app.js
@@ -57,12 +57,7 @@ Pebble.addEventListener('showConfiguration', function(e) {
 
     // TODO replace with a loop, remove duplicate code
   var background_color = getStorageValue('background_color', null);
-    if (background_color === null)
-    {
-        // FIXME loose this....
-        background_color = default_dict.background_color;
-    }
-    else
+    if (background_color !== null)
     {
         default_dict.background_color = background_color;
         console.log('about to remove old localStorage item background_color');
@@ -70,12 +65,7 @@ Pebble.addEventListener('showConfiguration', function(e) {
     }
 
   var time_color = getStorageValue('time_color', null);
-    if (time_color === null)
-    {
-        // FIXME loose this....
-        time_color = default_dict.time_color;
-    }
-    else
+    if (time_color !== null)
     {
         default_dict.time_color = time_color;
         console.log('about to remove old localStorage item time_color');
@@ -83,12 +73,7 @@ Pebble.addEventListener('showConfiguration', function(e) {
     }
 
   var vibrate_disconnect = getStorageValue('vibrate_disconnect', null);
-    if (vibrate_disconnect === null)
-    {
-        // FIXME loose this....
-        vibrate_disconnect = default_dict.vibrate_disconnect;
-    }
-    else
+    if (vibrate_disconnect !== null)
     {
         default_dict.vibrate_disconnect = vibrate_disconnect;
         console.log('about to remove old localStorage item vibrate_disconnect');

--- a/src/pebble-js-app.js
+++ b/src/pebble-js-app.js
@@ -108,6 +108,12 @@ Pebble.addEventListener('webviewclosed',
             */
             // TODO as configuration is untrusted and may be missing values, merge in from default_dict
 
+            /* even though we don't realy trust `configuration`, store it in local phone storage */
+            // TODO store dictionary instead - which stores number differently
+            console.log('store config on phone');
+            localStorage.setItem('stored_dict', JSON.stringify(configuration));
+
+            // Send to Pebble
             if ('vibrate_disconnect' in configuration)
             {
                 switch (configuration.vibrate_disconnect) {
@@ -127,16 +133,11 @@ Pebble.addEventListener('webviewclosed',
             }
             var dictionary = {
               "KEY_TIME_COLOR": parseInt(configuration.time_color, 16),
-              "KEY_BACKGROUND_COLOR": parseInt(configuration.background_color, 16), // FIXME if mising default value..
+              "KEY_BACKGROUND_COLOR": parseInt(configuration.background_color, 16),
               "KEY_VIBRATE_ON_DISCONNECT": vibrate_disconnect
             };
-            /* even though we don't realy trust `configuration`, store it in local phone storage */
-            // TODO store dictionary instead - which stores number differently
-            console.log('store config on phone');
-            localStorage.setItem('stored_dict', JSON.stringify(configuration));
 
             console.log('dictionary to send to Pebble' + JSON.stringify(dictionary));
-            // Send to Pebble
             Pebble.sendAppMessage(dictionary,
                 function(e) {
                     console.log("Configuration sent to Pebble successfully!");

--- a/src/pebble-js-app.js
+++ b/src/pebble-js-app.js
@@ -158,23 +158,28 @@ Pebble.addEventListener('webviewclosed',
         console.log('e.response: ' + e.response);
         console.log('e.response.length: ' + e.response.length);
         try {
-            var configuration = JSON.parse(decodeURIComponent(e.response));
-            var vibrate_disconnect = 0;
-
-            console.log('dictionary to validate ' + JSON.stringify(configuration));
+            var configuration_from_page = JSON.parse(decodeURIComponent(e.response));
+            console.log('dictionary to validate ' + JSON.stringify(configuration_from_page));
             /*
-            ** configuration can from an external web site, this is not trustworthy
-            ** and so needs validation. This avoids needing to add lots of
-            ** protection to the C code on the Pebble.
+            ** configuration_from_page is from an external web site,
+            ** this is not trustworthy and so needs validation.
+            ** Validation/translation reduces the need for _some_
+            ** protection C code on the Pebble.
             */
-            // TODO as configuration is untrusted and may be missing values, merge in from default_dict
 
-            /* even though we don't realy trust `configuration`, store it in local phone storage */
-            // TODO store dictionary instead - which stores number differently
+            /*
+            ** As configuration is untrusted and may be missing values,
+            ** merge in from default_dict
+            */
+            var configuration = merge_options(default_dict, configuration_from_page);
+
+            /* even though we don't really trust `configuration`, store it in local phone storage */
+            // TODO store (validated) dictionary (below) instead - which stores color settings differently
             console.log('store config on phone');
             localStorage.setItem('stored_dict', JSON.stringify(configuration));
 
             // Send to Pebble
+            var vibrate_disconnect = 0;
             if ('vibrate_disconnect' in configuration)
             {
                 switch (configuration.vibrate_disconnect) {

--- a/src/pebble-js-app.js
+++ b/src/pebble-js-app.js
@@ -201,6 +201,9 @@ Pebble.addEventListener('webviewclosed',
             */
             var configuration = merge_options(default_dict, configuration_from_page);
 
+            /* Validate config */
+            configuration.vibrate_disconnect = force_bool(configuration.vibrate_disconnect);
+
             /* even though we don't really trust `configuration`, store it in local phone storage */
             // TODO store (validated) dictionary (below) instead - which stores color settings differently
             console.log('store config on phone');
@@ -210,7 +213,7 @@ Pebble.addEventListener('webviewclosed',
             var dictionary = {
               "KEY_TIME_COLOR": parseInt(configuration.time_color, 16),  // TODO color not validated
               "KEY_BACKGROUND_COLOR": parseInt(configuration.background_color, 16),  // TODO color not validated
-              "KEY_VIBRATE_ON_DISCONNECT": force_bool(configuration.vibrate_disconnect) ? 1 : 0  // Force to int
+              "KEY_VIBRATE_ON_DISCONNECT": configuration.vibrate_disconnect ? 1 : 0  // Force to int
             };
 
             console.log('dictionary to send to Pebble' + JSON.stringify(dictionary));

--- a/src/pebble-js-app.js
+++ b/src/pebble-js-app.js
@@ -56,6 +56,26 @@ Pebble.addEventListener('showConfiguration', function(e) {
         stored_dict = JSON.parse(stored_dict_str);
     }
     console.log('stored_dict: ' + JSON.stringify(stored_dict));
+    console.log('default_dict: ' + JSON.stringify(default_dict));
+
+    /* Handle old config - not stored in dict */
+    console.log('Checking old (non-dict) config items');
+    var old_config_names = ['background_color', 'time_color', 'vibrate_disconnect'];
+    for (var i in old_config_names)
+    {
+        var config_name=old_config_names[i];
+        var tmp_setting;
+        console.log('i=' + i + '=' + config_name);
+        tmp_setting = getStorageValue(config_name, null);
+        if (tmp_setting !== null)
+        {
+            default_dict[config_name] = tmp_setting;
+            console.log('about to remove old localStorage item ' + config_name);
+            localStorage.removeItem(config_name);
+        }
+    }
+
+    var configuration = merge_options(default_dict, stored_dict);
     if (Pebble.getActiveWatchInfo)
     {
         /*
@@ -64,9 +84,9 @@ Pebble.addEventListener('showConfiguration', function(e) {
         */
         var info = Pebble.getActiveWatchInfo();
         console.log('Pebble info: ' + JSON.stringify(info));
-        default_dict.pebble_platform = info.platform;
-        default_dict.pebble_model = info.model;
-        default_dict.pebble_language = info.language;
+        configuration.pebble_platform = info.platform;
+        configuration.pebble_model = info.model;
+        configuration.pebble_language = info.language;
         /*
         ** Useful info:
             platform: aplite|basalt|chalk
@@ -115,27 +135,6 @@ Pebble.addEventListener('showConfiguration', function(e) {
         ** NOTE emulator with 3.8 SDK for aplite does have this info.
         */
     }
-
-    console.log('default_dict: ' + JSON.stringify(default_dict));
-
-    /* Handle old config - not stored in dict */
-    console.log('Checking old (non-dict) config items');
-    var old_config_names = ['background_color', 'time_color', 'vibrate_disconnect'];
-    for (var i in old_config_names)
-    {
-        var config_name=old_config_names[i];
-        var tmp_setting;
-        console.log('i=' + i + '=' + config_name);
-        tmp_setting = getStorageValue(config_name, null);
-        if (tmp_setting !== null)
-        {
-            default_dict[config_name] = tmp_setting;
-            console.log('about to remove old localStorage item ' + config_name);
-            localStorage.removeItem(config_name);
-        }
-    }
-
-    var configuration = merge_options(default_dict, stored_dict);
     console.log('configuration: ' + JSON.stringify(configuration));
 
     var param_array = [];


### PR DESCRIPTION
Instead of storing each config item individually on the phone, use a dict.

This makes adding (or even removing) items easier as there is no longer the need to change code related to storage. It does *not* eliminate the need for validation/conversion code.

Code in place to handle upgrades where individual items where save to localstorage.